### PR TITLE
Support for Inlined resources.

### DIFF
--- a/includes/PreviewFactory.java
+++ b/includes/PreviewFactory.java
@@ -10,10 +10,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcRepresentation;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
 import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
 import org.eclipse.lyo.oslc4j.core.model.Link;
 import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.Representation;
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +28,11 @@ public class PreviewFactory {
 			for (String getterMethodName : getterMethodNames) {
 				getterMethod = aResource.getClass().getMethod(getterMethodName);
 				boolean multiple = getterMethod.getAnnotation(OslcOccurs.class).value().equals(Occurs.ZeroOrMany) || getterMethod.getAnnotation(OslcOccurs.class).value().equals(Occurs.OneOrMany);
-				boolean showPropertyValueAsLink = (null != getterMethod.getAnnotation(OslcValueType.class)) && (getterMethod.getAnnotation(OslcValueType.class).value().equals(ValueType.Resource));
+                boolean showPropertyValueAsLink = ((null != getterMethod.getAnnotation(OslcValueType.class)) && (getterMethod.getAnnotation(OslcValueType.class).value().equals(ValueType.Resource))) //aResource is of type Resource
+                        && //aResource is not defined to be Inlined
+                        ((null == getterMethod.getAnnotation(OslcRepresentation.class)) 
+                                || 
+                        (((null != getterMethod.getAnnotation(OslcRepresentation.class)) && (!getterMethod.getAnnotation(OslcRepresentation.class).value().equals(Representation.Inline)))));
 				PropertyDefintion key;
 				if (showPropertyHeadingsAsLinks) {
 					key = constructPropertyDefintion(getterMethod.getAnnotation(OslcPropertyDefinition.class).value(), getterMethod.getAnnotation(OslcName.class).value());


### PR DESCRIPTION
Now that we can support (non-local) Resources that can be inlined, we need to make oslc-ui work against taht.